### PR TITLE
config-changed hook works properly with async updateConfig

### DIFF
--- a/hooks/config-changed
+++ b/hooks/config-changed
@@ -16,7 +16,7 @@ var fs = require('fs'),
 function updateConfig(error, config) {
   config = JSON.parse(config);
   utils.renderTemplate(
-    config, 'config.js.template', '/var/www/ghost/config.js')
+    config, 'config.js.template', '/var/www/ghost/config.js');
   exec('chown -R ubuntu:ubuntu /var/www/ghost');
   exec('service ghost start');
 }


### PR DESCRIPTION
This was originally meant as a fix for the port config option, but that's due to elevated perms.  That is another issue that will be fixed by exposing http interface.  Instead, this assures that config-changed operations take place in the right order, thanks to async updateConfig.

To QA:
- deploy
- `juju set ghost port=5523`
- Ensure ghost is visible on port 5523
